### PR TITLE
Return error when token is empty, undefined, or null.

### DIFF
--- a/index.js
+++ b/index.js
@@ -61,6 +61,12 @@ Authy.prototype.verify = function (id, token, force, callback) {
     }
 
     cleanToken = String(token).replace(/\D/g, "").substring(0, 16)
+
+    if (cleanToken === '' || cleanToken == null) {
+        callback(new Error("argument 'token' cannot be empty, null, or undefined"));
+        return;
+    }
+
     // Overwrite the default body to check the response.
     check_body_callback = function(err, res) {
         if(!err && res.token != "is valid") {

--- a/tests/tests.js
+++ b/tests/tests.js
@@ -109,6 +109,36 @@ exports['Verify Token - Dirty'] = function (test) {
     });
 };
 
+exports['Verify Token - Empty String'] = function (test) {
+    authy.verify(test_user.id, '', true, function (err, res) {
+        test.ok(!res);
+        test.equal(typeof(res), 'undefined', 'Response should be undefined.');
+        test.ok(err instanceof Error);
+        test.equal(err.toString(), "Error: argument 'token' cannot be empty, null, or undefined");
+        test.done();
+    });
+};
+
+exports['Verify Token - Null'] = function (test) {
+    authy.verify(test_user.id, null, true, function (err, res) {
+        test.ok(!res);
+        test.equal(typeof(res), 'undefined', 'Response should be undefined.');
+        test.ok(err instanceof Error);
+        test.equal(err.toString(), "Error: argument 'token' cannot be empty, null, or undefined");
+        test.done();
+    });
+};
+
+exports['Verify Token - Undefined'] = function (test) {
+    authy.verify(test_user.id, undefined, true, function (err, res) {
+        test.ok(!res);
+        test.equal(typeof(res), 'undefined', 'Response should be undefined.');
+        test.ok(err instanceof Error);
+        test.equal(err.toString(), "Error: argument 'token' cannot be empty, null, or undefined");
+        test.done();
+    });
+};
+
 /*
  *  Request SMS Tests
  */


### PR DESCRIPTION
Currently, a call like:
```javascript
authy.verify(authyUserId, twoFactorCode, callback);
```
will return
```javascript
{ message: 'Requested URL was not found. Please check http://docs.authy.com/ to see the valid URLs',
  success: false,
  errors: { message: 'Requested URL was not found. Please check http://docs.authy.com/ to see the valid URLs' } }
  ```
when `twoFactorCode` is equal to `''`, `null`, or `undefined`.

I think it'd be clearer to callback with a direct error here (in this case, that the token cannot be null/missing) as opposed to returning a more obscure 404 API response.
  